### PR TITLE
Fixed file name cases for case-sensitive systems

### DIFF
--- a/Modules/ConnectivityModule/APTableCell.h
+++ b/Modules/ConnectivityModule/APTableCell.h
@@ -1,4 +1,4 @@
-#import <AirportSettings/APTableCell.h>
+#import <AirPortSettings/APTableCell.h>
 #import <MaizeUI/MZEMaterialView.h>
 
 @interface APTableCell (MZE)

--- a/Modules/ConnectivityModule/MZEConnectivityWifiViewController.m
+++ b/Modules/ConnectivityModule/MZEConnectivityWifiViewController.m
@@ -1,4 +1,4 @@
-#import "MZEConnectivityWiFiViewController.h"
+#import "MZEConnectivityWifiViewController.h"
 #import <SpringBoard/SBWiFiManager+Private.h>
 #import "MZEConnectivityWiFiNetworksViewController.h"
 


### PR DESCRIPTION
Compiling a freshly cloned copy of Maize results in an error caused by these two import statements referencing files with different casing.

`specified path differs in case from file name on disk [-Werror,-Wnonportable-include-path]`

